### PR TITLE
GetReportRequestStatus

### DIFF
--- a/amazonmws.go
+++ b/amazonmws.go
@@ -147,3 +147,11 @@ func (api AmazonMWSAPI) GetMyFeesEstimate(items []FeeEstimateRequest) (string, e
 
 	return api.genSignAndFetchViaPost("GetMyFeesEstimate", "/Products/2011-10-01", params)
 }
+
+func (api AmazonMWSAPI) GetReportRequestStatus(reportID string) (string, error) {
+	params := make(map[string]string)
+
+	params["ReportRequestIdList.Id.1"] = reportID
+
+	return api.genSignAndFetch("GetReportRequestList", "/Reports/2009-01-01", params)
+}


### PR DESCRIPTION
Hi, Tom!

I've incountered a small problem when trying to add some Reports functionality. Products and Reports belong to different api versions "2011-10-01" and "2009-01-01" respectively.

The package currently hardcodes the "2011-10-01" version. I resolved this problem by extracting the version from "actionPath" via regular expression. Tried some live testing to make sure nothing is broken (not part of the PR), everything seems to work fine, both Reports and Products.